### PR TITLE
IWA-Hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,9 @@
                         avoiding these hosts if possible.</p>
                     <hr>
                     <ul>
+                        <li data-placement="left" data-toggle="tooltip" title="Owners are extremely salty. Uses default everything on their website. Had a .nl domain but changed it to .eu. Owners spam emails and claim “our website is near completion” also at one point said they developed their billing panel which is obviously just default WHMCS...">
+                            <a href="https://Iwa-hosting.eu">IWA-Hosting.eu</a>
+                        </li>
                         <li data-placement="left" data-toggle="tooltip" title="Using nulled WHMCS and doubled down on it saying he does not see a point in spending money on something he can get for free. Super shady Discord, selling stuffs like Spotify accounts to claiming that they have a $3000 DDOS Protection (which we highly doubt they have - they can't even spend $15 on a WHMCS license).">
                             <a href="https://server642.com">Server642.com</a>
                         </li>


### PR DESCRIPTION
• Toxic Owners
• Spams emails
• Is currently listed on the old SummerHost.club site.
• Domain has changed to IWA-Hosting.eu