### PR TITLE
Added TermsGames to the Vault

### DIFF
--- a/vault/index.html
+++ b/vault/index.html
@@ -233,6 +233,20 @@
             <a tabindex="0" data-toggle="popover" data-trigger="focus" title="Information" data-content="Sorry, we're currently developing this page!">Read More</a>
         </span>
     </div>
+    <div class="card">
+        <a href="#">
+            <img src="assets/termsgames/termsgames-logo.png" class="card-img-top" alt="Logo of TermsGames">
+            <div class="card-body">
+                <h5 class="card-title">TermsGames</h5>
+        </a>
+        <p class="card-text">Sold machines to people and when he ran out of money to keep them up, he took them offline without allowing backups to be made. Has been caught selling dodgy windows keys and trying to resell nulled themes. Banned people on his discord for not giving him $15 on request. Scammed people by offering setup services and ghosting after getting money. When asked for money back he said he didn't care. Owner of Venelium Hosting Ltd (11102714) and Voroid Unturned Community.</p>
+    </div>
+    <div class="card-footer">
+        <small class="text-muted">Last updated May 25, 2019</small> <!-- Make sure you Update! -->
+        <span style="float:right;">
+            <a tabindex="0" data-toggle="popover" data-trigger="focus" title="Information" data-content="Sorry, we're currently developing this page!">Read More</a>
+        </span>
+    </div>
     </div>
     </div>
     <!-- Optional JavaScript -->


### PR DESCRIPTION
Added TermsGames to the vault for scamming, selling dodgy windows keys, reselling nulled themes, banning people if they don't give him money, shutting down his clients machines and not allowing backups when he can't afford to keep the machines on.

Proof below:

https://cdn.discordapp.com/attachments/439504615684177940/581790657333690372/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581790740468989972/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581790878855856138/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581840609405304842/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581841084552839179/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581842581802188819/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581842886287556630/unknown.png

https://cdn.discordapp.com/attachments/439504615684177940/581843419433795595/unknown.png

I would have liked to add his host `veneliumhosting.com` to the SH list, however there's little wrong with the company itself as they have a valid WHMCS license and aren't doing anything else sketchy. It's just the owner himself who is an utter cock and deserves to be on this list for being a douche. 

The owner also has been a part of communities in the past and decided to branch away from them and chat shit behind the owners backs. Please note that I was not involved with TermsGames in any way, nor was I involved with Jonny when these events occurred, I'm simply submitting the PR with as much evidence as I can give, as the guys hosting company looks sketchy at best, with outrageous pricing and the owner as I have said has shown himself to be a massive cock.